### PR TITLE
fix: show policy definition id in deletion dialog

### DIFF
--- a/src/modules/edc-demo/components/policy-view/policy-view.component.ts
+++ b/src/modules/edc-demo/components/policy-view/policy-view.component.ts
@@ -73,7 +73,7 @@ export class PolicyViewComponent implements OnInit {
   }
 
   delete(policy: PolicyDefinition) {
-    const dialogData = ConfirmDialogModel.forDelete('policy', policy.id);
+    const dialogData = ConfirmDialogModel.forDelete('policy', policy.id || policy.uid as string);
     const ref = this.dialog.open(ConfirmationDialogComponent, {
       maxWidth: '20%',
       data: dialogData,

--- a/src/modules/edc-dmgmt-client/model/policyDefinition.ts
+++ b/src/modules/edc-dmgmt-client/model/policyDefinition.ts
@@ -14,6 +14,7 @@ import { Policy } from './policy';
 
 export interface PolicyDefinition {
     policy: Policy;
+    uid?: string;
     id: string;
 }
 


### PR DESCRIPTION
# Pull Request
This is an attempt to fix an issue with the deletion confirmation dialog in policy definitions page.
## How Has This Been Tested?
By checking the same dialog where the bug was happening.

## Linked Issue(s)
- fixes # ([issue](https://github.com/sovity/edc-ui/issues/43))

# Checklist
- [ ] I have **formatted the title** correctly and precisely
- [ ] My code follows the **style guidelines** of this project
- [ ] I have performed a **self-review** of my own code
- [ ] I have **commented** my code, particularly in hard-to-understand areas and public classes/methods
- [ ] I have made corresponding changes to the **documentation**
- [ ] My changes generate **no new warnings** (performed checkstyle check locally)
- [ ] I have added **tests that prove my fix** is effective or that my feature works
- [ ] New and existing unit **tests pass locally** with my changes
- [ ] Any dependent **changes have been merged** and published in downstream modules
- [ ] I have added/updated **copyright headers**
