### PR TITLE
fix transfer process initiation not working

### DIFF
--- a/src/modules/edc-demo/services/policy-definition-builder.ts
+++ b/src/modules/edc-demo/services/policy-definition-builder.ts
@@ -40,7 +40,6 @@ export class PolicyDefinitionBuilder {
     return {
       edctype: 'dataspaceconnector:permission',
       id: null,
-      target: 'urn:artifact:urn:artifact:bitcoin',
       action: {type: 'USE'},
       constraints: [
         {
@@ -66,7 +65,6 @@ export class PolicyDefinitionBuilder {
     return {
       edctype: 'dataspaceconnector:permission',
       id: null,
-      target: 'urn:artifact:urn:artifact:bitcoin',
       action: {type: 'USE'},
       constraints: [
         {

--- a/src/modules/edc-dmgmt-client/api/contractAgreement.service.ts
+++ b/src/modules/edc-dmgmt-client/api/contractAgreement.service.ts
@@ -24,6 +24,9 @@ import { ContractAgreementDto } from '../model/contractAgreementDto';
 // @ts-ignore
 import {API_KEY, BASE_PATH, COLLECTION_FORMATS, CONNECTOR_DATAMANAGEMENT_API} from '../variables';
 import { Configuration }                                     from '../configuration';
+import {TransferRequestDto} from "../model/transferRequestDto";
+import {TransferId} from "../model/transferId";
+import {DataAddressDto} from "../model/dataAddressDto";
 
 
 
@@ -224,5 +227,23 @@ export class ContractAgreementService {
             }
         );
     }
+  initiateTransfer(id: string, dataAddressDto: DataAddressDto): Observable<TransferId> {
+    if (id == null) {
+      throw new Error('Required parameter id was null or undefined when calling initiateTransfer.');
+    }
 
+    if (dataAddressDto == null) {
+      throw new Error('Required parameter dataAddressDto was null or undefined when calling initiateTransfer.');
+    }
+
+    let url = `${this.configuration.basePath}/contractagreements/${encodeURIComponent(String(id))}/initiatetransfer`;
+    return this.httpClient.post<TransferId>(
+      url,
+      dataAddressDto,
+      {
+        withCredentials: this.configuration.withCredentials,
+        headers: this.defaultHeaders,
+      }
+    );
+  }
 }


### PR DESCRIPTION
Initiating transfer processes is faulty due to backend expecting data from contract definitions which aren't present in contract agreements causing us to write our own extension to fix this issue short-term.