### PR TITLE
chore: add continue on error if couldn't automerge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -11,6 +11,7 @@ jobs:
 
   automerge:
     runs-on: ubuntu-latest
+    continue-on-error: true
     permissions:
       pull-requests: write
       contents: write


### PR DESCRIPTION
Unfortunately it is not possible to mark a failing job as green. 

https://github.com/actions/runner/issues/2347