### PR TITLE
fix: Placeholder URLs missing "/catalog/" path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ the detailed section referring to by linking pull requests or issues.
 #### Removed
 
 #### Fixed
+- Placeholder URLs missing "/catalog/" path
 
 ## [v0.0.1-milestone-7-sovity3] 06.02.2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ the detailed section referring to by linking pull requests or issues.
 #### Removed
 
 #### Fixed
-- Placeholder URLs missing "/catalog/" path
+- Placeholder URLs missing "/control/" path
 
 ## [v0.0.1-milestone-7-sovity3] 06.02.2023
 

--- a/src/modules/edc-demo/components/catalog-browser/catalog-browser.component.html
+++ b/src/modules/edc-demo/components/catalog-browser/catalog-browser.component.html
@@ -23,7 +23,7 @@
       <mat-icon matPrefix>link</mat-icon>
       <input
         matInput
-        placeholder="https://other-connector.com/api/v1/ids/data"
+        placeholder="https://other-connector.com/control/api/v1/ids/data"
         [(ngModel)]="customProviders"
         (input)="onCatalogUrlsChange()" />
       <mat-hint

--- a/src/modules/edc-demo/components/new-policy-dialog/new-policy-dialog.component.html
+++ b/src/modules/edc-demo/components/new-policy-dialog/new-policy-dialog.component.html
@@ -54,7 +54,7 @@
       <mat-label>Connector ID</mat-label>
       <input
         matInput
-        placeholder="https://other-connector.com/api/v1/ids/data"
+        placeholder="https://other-connector.com/control/api/v1/ids/data"
         [formControl]="form.group.controls.connectorId" />
     </mat-form-field>
   </div>


### PR DESCRIPTION
# Pull Request
Placeholder URLs were missing "/catalog/" path.

# Checklist

-   [x] I have **formatted the title** correctly and precisely
-   [x] My code follows the **style guidelines** of this project
-   [x] I have performed a **self-review** of my own code
-   [x] I have **commented** my code, particularly in hard-to-understand areas and public classes/methods
-   [x] I have made corresponding changes to the **documentation**
-   [x] My changes generate **no new warnings** (performed checkstyle check locally)
-   [ ] I have added **tests that prove my fix** is effective or that my feature works
-   [x] New and existing unit **tests pass locally** with my changes
-   [x] Any dependent **changes have been merged** and published in downstream modules
-   [x] I have added/updated **copyright headers**
