### PR TITLE
fix keyword select not adding value on blur

### DIFF
--- a/src/modules/edc-demo/components/keyword-select/keyword-select.component.html
+++ b/src/modules/edc-demo/components/keyword-select/keyword-select.component.html
@@ -14,6 +14,7 @@
     </mat-chip>
     <input
       placeholder="Add keyword..."
+      [matChipInputAddOnBlur]="true"
       [matChipInputFor]="chipList"
       [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
       (matChipInputTokenEnd)="add($event)" />

--- a/src/modules/edc-demo/components/keyword-select/keyword-select.component.ts
+++ b/src/modules/edc-demo/components/keyword-select/keyword-select.component.ts
@@ -1,4 +1,4 @@
-import {COMMA, ENTER} from '@angular/cdk/keycodes';
+import {COMMA, ENTER, SEMICOLON} from '@angular/cdk/keycodes';
 import {Component, HostBinding, Input} from '@angular/core';
 import {FormControl} from '@angular/forms';
 import {MatChipInputEvent} from '@angular/material/chips';
@@ -9,7 +9,7 @@ import {removeOnce} from '../../utils/array-utils';
   templateUrl: 'keyword-select.component.html',
 })
 export class KeywordSelectComponent {
-  separatorKeysCodes: number[] = [ENTER, COMMA];
+  separatorKeysCodes: number[] = [ENTER, COMMA, SEMICOLON];
 
   @Input()
   label!: string;
@@ -26,10 +26,13 @@ export class KeywordSelectComponent {
   }
 
   add(event: MatChipInputEvent): void {
-    const keyword = (event.value || '').trim();
-    if (keyword) {
-      this.control.setValue([...this.control.value, keyword]);
+    const keywords = (event.value || '')
+      .split(/[,;]/)
+      .map((it) => it.trim())
+      .filter((it) => it);
+    if (keywords.length) {
+      this.control.setValue([...this.control.value, ...keywords]);
     }
-    event.chipInput!.clear();
+    event.chipInput.clear();
   }
 }


### PR DESCRIPTION
- closes #118 
- keyword select now adds text as tag on blur
- keyword select now splits pasted text with separators by separators
- added semicolon separator, although it won't instantly split tags due to "keycode" limitation on german keyboards where the semicolon is two keystrokes "Shift + Comma" and Angular Material API expecting semicolons. When blurring or pressing enter, keywords will be split by semicolon either way.