### PR TITLE
fix typo

### DIFF
--- a/src/modules/edc-demo/components/contract-definition-page/contract-definition-page.component.html
+++ b/src/modules/edc-demo/components/contract-definition-page/contract-definition-page.component.html
@@ -25,7 +25,7 @@
       style="margin-top: 8px; height: 44px"
       (click)="onCreate()">
       <mat-icon>add_circle_outline</mat-icon>
-      Create contractDefinition
+      Create Contract Definition
     </button>
 
     <!-- Spacer -->


### PR DESCRIPTION
fixes typo "Create contractDefinition" => "Create Contract Definition"