### PR TITLE
fix: closing navbar on pressing escape button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ the detailed section referring to by linking pull requests or issues.
 
 #### Fixed
 
+- Fixed closing of side nav-bar on pressing escape button
+
 ## [v0.0.1-milestone-7-sovity7] 06.03.2023
 
 ### Overview

--- a/src/modules/app/components/navigation/navigation.component.html
+++ b/src/modules/app/components/navigation/navigation.component.html
@@ -3,6 +3,7 @@
     class="sidenav"
     #drawer
     fixedInViewport
+    [disableClose]="true"
     [attr.role]="(isHandset$ | async) ? 'dialog' : 'navigation'"
     [mode]="(isHandset$ | async) ? 'over' : 'side'"
     [opened]="(isHandset$ | async) === false">


### PR DESCRIPTION
# Pull Request

Fixed closing of side nav-bar on pressing escape

## How Has This Been Tested?
With mock backend 

## PR is blocked by

- [ ] blocked by #160 

# Checklist

- [x] I have **formatted the title** correctly and precisely
- [x] My code follows the **style guidelines** of this project
- [x] I have performed a **self-review** of my own code
- [ ] I have **commented** my code, particularly in hard-to-understand areas and public classes/methods
- [x] I have made corresponding changes to the **documentation**
- [x] My changes generate **no new warnings** (performed checkstyle check locally)
- [ ] I have added **tests that prove my fix** is effective or that my feature works
- [x] New and existing unit **tests pass locally** with my changes
- [ ] Any dependent **changes have been merged** and published in downstream modules
- [ ] I have added/updated **copyright headers**
