### PR TITLE
fix: better catalog fetch details icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ the detailed section referring to by linking pull requests or issues.
 
 #### Changed
 
+- Updated the icon for Fetch Status option in the catalog browser
+
 #### Removed
 
 #### Fixed

--- a/src/modules/edc-demo/components/catalog-browser-fetch-detail-dialog/catalog-browser-fetch-detail-dialog.component.html
+++ b/src/modules/edc-demo/components/catalog-browser-fetch-detail-dialog/catalog-browser-fetch-detail-dialog.component.html
@@ -1,6 +1,6 @@
 <div class="mat-card-header">
   <mat-icon style="font-size: 40px; width: 40px; height: 40px; min-width: 40px">
-    sim_card
+    view_timeline
   </mat-icon>
   <div class="mat-card-header-text">
     <div class="mat-card-title">Fetch Status</div>


### PR DESCRIPTION
# Pull Request

Updated icon for fetch details option in the Catalog browser 

## How Has This Been Tested?

With mock backend

## PR is blocked by

- [ ] blocked by #163 

# Checklist

- [x] I have **formatted the title** correctly and precisely
- [x] My code follows the **style guidelines** of this project
- [x] I have performed a **self-review** of my own code
- [ ] I have **commented** my code, particularly in hard-to-understand areas and public classes/methods
- [x] I have made corresponding changes to the **documentation**
- [x] My changes generate **no new warnings** (performed checkstyle check locally)
- [ ] I have added **tests that prove my fix** is effective or that my feature works
- [ ] New and existing unit **tests pass locally** with my changes
- [ ] Any dependent **changes have been merged** and published in downstream modules
- [ ] I have added/updated **copyright headers**
