### PR TITLE
fix dashboard data offers not called contract definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ the detailed section referring to by linking pull requests or issues.
 #### Fixed
 
 - Fixed closing of side nav-bar on pressing escape button
+- Fixed "Your Contract Definitions" being called "Your Data Offers" in the
+  dashboard.
 
 ## [v0.0.1-milestone-7-sovity7] 06.03.2023
 

--- a/fake-backend/json/policyDefinitions.json
+++ b/fake-backend/json/policyDefinitions.json
@@ -1,5 +1,50 @@
 [
   {
+    "createdAt": 1677833530781,
+    "id": "always-true",
+    "policy": {
+      "permissions": [
+        {
+          "edctype": "dataspaceconnector:permission",
+          "uid": null,
+          "target": null,
+          "action": {
+            "type": "USE",
+            "includedIn": null,
+            "constraint": null
+          },
+          "assignee": null,
+          "assigner": null,
+          "constraints": [
+            {
+              "edctype": "AtomicConstraint",
+              "leftExpression": {
+                "edctype": "dataspaceconnector:literalexpression",
+                "value": "ALWAYS_TRUE"
+              },
+              "rightExpression": {
+                "edctype": "dataspaceconnector:literalexpression",
+                "value": "true"
+              },
+              "operator": "EQ"
+            }
+          ],
+          "duties": []
+        }
+      ],
+      "prohibitions": [],
+      "obligations": [],
+      "extensibleProperties": {},
+      "inheritsFrom": null,
+      "assigner": null,
+      "assignee": null,
+      "target": null,
+      "@type": {
+        "@policytype": "set"
+      }
+    }
+  },
+  {
     "uid": "time-restricted-policy",
     "policy": {
       "permissions": [

--- a/src/modules/edc-demo/components/dashboard/dashboard.component.html
+++ b/src/modules/edc-demo/components/dashboard/dashboard.component.html
@@ -27,7 +27,7 @@
     <div class="flex flex-row flex-wrap gap-[16px]">
       <edc-demo-dashboard-kpi-card
         class="flex-even-sized"
-        label="Your Data Offerings"
+        label="Your Contract Definitions"
         [kpi]="data.numContractDefinitions"></edc-demo-dashboard-kpi-card>
 
       <edc-demo-dashboard-kpi-card


### PR DESCRIPTION
- fix dashboard contract definitions being called "data offers"