### PR TITLE
2023 04 12 logout history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ the detailed section referring to by linking pull requests or issues.
 - Fixed getting started docker-compose-yaml to use the newly renamed `edc-dev`
   image.
 - Fixed labels of MDS categories and sub-categories.
+- Fixed issue when navigating back after clicking logout.
 
 ## [v0.0.1-milestone-8-sovity2] 24.03.2023
 

--- a/src/modules/app/app.module.ts
+++ b/src/modules/app/app.module.ts
@@ -16,6 +16,7 @@ import {MatToolbarModule} from '@angular/material/toolbar';
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {NgChartsModule} from 'ng2-charts';
+import {PreviousRouteListener} from '../edc-demo/components/logout/previous-route-listener';
 import {EdcDemoModule} from '../edc-demo/edc-demo.module';
 import {API_KEY, CONNECTOR_DATAMANAGEMENT_API} from '../edc-dmgmt-client';
 import {ApiKeyInterceptor} from './api-key.interceptor';
@@ -71,7 +72,7 @@ import {AppConfigService} from './config/app-config.service';
 
     {provide: HTTP_INTERCEPTORS, multi: true, useClass: ApiKeyInterceptor},
 
-    MatDatepickerModule,
+    PreviousRouteListener,
     {
       provide: MAT_FORM_FIELD_DEFAULT_OPTIONS,
       useValue: {
@@ -82,4 +83,9 @@ import {AppConfigService} from './config/app-config.service';
   ],
   bootstrap: [AppComponent],
 })
-export class AppModule {}
+export class AppModule {
+  constructor(
+    // Ensure PreviousRouteListener is instantiated
+    previousRouteListener: PreviousRouteListener,
+  ) {}
+}

--- a/src/modules/edc-demo/components/contract-definition-editor-dialog/contract-definition-editor-dialog.component.ts
+++ b/src/modules/edc-demo/components/contract-definition-editor-dialog/contract-definition-editor-dialog.component.ts
@@ -45,7 +45,6 @@ export class ContractDefinitionEditorDialog implements OnInit, OnDestroy {
       .pipe(takeUntil(this.ngOnDestroy$))
       .subscribe((polices) => {
         this.policies = polices;
-        console.log(this.policies);
       });
     this.assetService
       .getAllAssets(0, 10_000_000)

--- a/src/modules/edc-demo/components/logout/location-history-utils.ts
+++ b/src/modules/edc-demo/components/logout/location-history-utils.ts
@@ -1,0 +1,39 @@
+import {Location} from '@angular/common';
+import {Injectable} from '@angular/core';
+import {PreviousRouteListener} from './previous-route-listener';
+
+/**
+ * Required because:
+ *  - The logout action is currently a "page"/route instead of a navigation entry with a click/enter handler.
+ *  - This page should not be in location history or the back button won't work.
+ *  - For that we need to replace the logout page's state with the correct URL to return to.
+ *  - For that we need that URL in the first place.
+ */
+@Injectable({providedIn: 'root'})
+export class LocationHistoryUtils {
+  constructor(
+    private location: Location,
+    private previousRouteListener: PreviousRouteListener,
+  ) {}
+
+  replaceStateWithPreviousUrl(opts: {skipUrlsStartingWith: string}) {
+    const goodReplacementUrl = this.getGoodReplacementUrl(opts);
+    this.location.replaceState(goodReplacementUrl);
+  }
+
+  getGoodReplacementUrl(opts: {skipUrlsStartingWith: string}): string {
+    const urlsToTry: (string | null)[] = [
+      this.previousRouteListener.currentUrl,
+      this.previousRouteListener.previousUrl,
+
+      // Fallback to dashboard
+      '/',
+    ];
+
+    let url = urlsToTry.find(
+      (url) => url && !url.startsWith(opts.skipUrlsStartingWith),
+    );
+
+    return url ?? urlsToTry[urlsToTry.length - 1]!!;
+  }
+}

--- a/src/modules/edc-demo/components/logout/logout.component.ts
+++ b/src/modules/edc-demo/components/logout/logout.component.ts
@@ -1,6 +1,7 @@
-import {DOCUMENT} from '@angular/common';
+import {DOCUMENT, Location} from '@angular/common';
 import {Component, Inject, OnInit} from '@angular/core';
 import {AppConfigService} from '../../../app/config/app-config.service';
+import {LocationHistoryUtils} from './location-history-utils';
 
 @Component({
   selector: 'app-logout',
@@ -9,11 +10,17 @@ import {AppConfigService} from '../../../app/config/app-config.service';
 })
 export class LogoutComponent implements OnInit {
   constructor(
+    private locationHistoryUtils: LocationHistoryUtils,
+    private location: Location,
     private appConfigService: AppConfigService,
     @Inject(DOCUMENT) private document: Document,
   ) {}
 
   ngOnInit(): void {
+    // Prevent back button hijacking from /logout in history
+    this.locationHistoryUtils.replaceStateWithPreviousUrl({
+      skipUrlsStartingWith: '/logout',
+    });
     this.document.location.href = this.appConfigService.config.logoutUrl!;
   }
 }

--- a/src/modules/edc-demo/components/logout/previous-route-listener.ts
+++ b/src/modules/edc-demo/components/logout/previous-route-listener.ts
@@ -1,0 +1,28 @@
+import {Injectable} from '@angular/core';
+import {NavigationEnd, Router} from '@angular/router';
+
+/**
+ * Required because:
+ *  - The logout action is currently a "page"/route instead of a navigation entry with a click/enter handler.
+ *  - This page should not be in location history or the back button won't work.
+ *  - For that we need to replace the logout page's state with the correct URL to return to.
+ *  - For that we need that URL in the first place.
+ */
+@Injectable()
+export class PreviousRouteListener {
+  previousUrl: string | null = null;
+  currentUrl: string | null = null;
+
+  constructor(private router: Router) {
+    this.startListeningToUrlChanges();
+  }
+
+  private startListeningToUrlChanges() {
+    this.router.events.subscribe((event) => {
+      if (event instanceof NavigationEnd) {
+        this.previousUrl = this.currentUrl;
+        this.currentUrl = event.url;
+      }
+    });
+  }
+}

--- a/src/modules/edc-demo/utils/form-group-utils.ts
+++ b/src/modules/edc-demo/utils/form-group-utils.ts
@@ -122,7 +122,6 @@ export function switchDisabledControlsByField2<
     const keys = opts.enabledControlsByValue.get(opts.switchCtrl.value);
     keys
       ?.map((it) => {
-        console.log('enabling', it);
         return it;
       })
       ?.map(ctrl)
@@ -134,7 +133,6 @@ export function switchDisabledControlsByField2<
     fields
       .filter((it) => !keys?.includes(it))
       ?.map((it) => {
-        console.log('disabling', it);
         return it;
       })
       .map(ctrl)


### PR DESCRIPTION
This is not a full fix as it will leave two entries in the history of the last visited page. The exact solution would be to remove the leak of the list of routes being re-used for the list of navigation menu entries.

closes https://github.com/sovity/PMO-Software/issues/144
