### PR TITLE
feat: Renamed button from cancel to close in json-dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ the detailed section referring to by linking pull requests or issues.
 
 #### Fixed
 
+- Renamed button from cancel to close in json-dialogs
+
 ## [v0.0.1-milestone-8-sovity12] 12.07.2023
 
 ### Overview

--- a/src/app/component-library/json-dialog/json-dialog/json-dialog.component.html
+++ b/src/app/component-library/json-dialog/json-dialog/json-dialog.component.html
@@ -38,7 +38,7 @@
   </div>
   <div class="flex flex-row">
     <button mat-dialog-close mat-button color="default" [disabled]="busy">
-      Cancel
+      Close
     </button>
     <button
       *ngIf="data.actionButton"


### PR DESCRIPTION
# Pull Request

Renamed button from cancel to close in json-dialogs

## How Has This Been Tested?
With Fake Backend


## PR is blocked by

-   [x] blocked by #https://github.com/sovity/edc-ui/issues/285

# Checklist

-   [ ] I have **formatted the title** correctly and precisely
-   [x] My code follows the **style guidelines** of this project
-   [x] I have performed a **self-review** of my own code
-   [ ] I have **commented** my code, particularly in hard-to-understand areas and public classes/methods
-   [ ] I have made corresponding changes to the **documentation**
-   [x] My changes generate **no new warnings** (performed checkstyle check locally)
-   [ ] I have added **tests that prove my fix** is effective or that my feature works
-   [ ] New and existing unit **tests pass locally** with my changes
-   [ ] Any dependent **changes have been merged** and published in downstream modules
-   [ ] I have added/updated **copyright headers**
