### PR TITLE
fix: broken /logout page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ the detailed section referring to by linking pull requests or issues.
 
 #### Patch
 
+- Fix broken `/logout` page
+
 #### Deployment Migration Notes
 
 ## [v2.2.0] 05.12.2023

--- a/src/app/routes/connector-ui/connector-ui.module.ts
+++ b/src/app/routes/connector-ui/connector-ui.module.ts
@@ -17,6 +17,7 @@ import {ConnectorUiComponent} from './connector-ui.component';
 import {ContractAgreementPageModule} from './contract-agreement-page/contract-agreement-page.module';
 import {ContractDefinitionPageModule} from './contract-definition-page/contract-definition-page.module';
 import {DashboardPageModule} from './dashboard-page/dashboard-page.module';
+import {LocationHistoryUtils} from './logout-page/location-history-utils';
 import {LogoutPageModule} from './logout-page/logout-page.module';
 import {PreviousRouteListener} from './logout-page/previous-route-listener';
 import {PolicyDefinitionPageModule} from './policy-definition-page/policy-definition-page.module';
@@ -55,7 +56,7 @@ import {TransferHistoryPageModule} from './transfer-history-page/transfer-histor
     ConnectorUiRoutingModule,
   ],
   declarations: [ConnectorUiComponent],
-  providers: [PreviousRouteListener],
+  providers: [PreviousRouteListener, LocationHistoryUtils],
 })
 export class ConnectorUiModule {
   constructor(previousRouteListener: PreviousRouteListener) {

--- a/src/app/routes/connector-ui/logout-page/location-history-utils.ts
+++ b/src/app/routes/connector-ui/logout-page/location-history-utils.ts
@@ -9,7 +9,7 @@ import {PreviousRouteListener} from './previous-route-listener';
  *  - For that we need to replace the logout page's state with the correct URL to return to.
  *  - For that we need that URL in the first place.
  */
-@Injectable({providedIn: 'root'})
+@Injectable()
 export class LocationHistoryUtils {
   constructor(
     private location: Location,


### PR DESCRIPTION
# Pull Request

Solves NullInjectionError of PreviousRouteListener and ensures a working`/logout` page.

## How Has This Been Tested?

Set `EDC_UI_ACTIVE_PROFILE=sovity-hosted-by-sovity` and click on the Logout button.

## Linked Issue(s)

closes #591