### PR TITLE
HTTP Data Transfer: Remove EDC prefix for headers in data address property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ the detailed section referring to by linking pull requests or issues.
 - Fixed an asset select issue resulting from a bad compare function
 - Asset: Fix double encoding of query params by disallowing '&' and '=' chars in
   form field and sending them unencoded
+- Fixed an issue that prevented custom headers from being included in HTTP Data Transfers
 
 #### Deployment Migration Notes
 

--- a/src/app/core/services/models/data-address-properties.ts
+++ b/src/app/core/services/models/data-address-properties.ts
@@ -5,7 +5,7 @@ export const DataAddressProperty = {
   authKey: `${EDC}authKey`,
   baseUrl: `${EDC}baseUrl`,
   body: `${EDC}body`,
-  header: `${EDC}header`,
+  header: `header`,
   contentType: `${EDC}contentType`,
   method: `${EDC}method`,
   pathSegments: `${EDC}pathSegments`,


### PR DESCRIPTION
This resolves #702 by not prefixing headers for the HTTP data transfer with the EDC namespace as the EDC expects them without, see https://github.com/eclipse-edc/Connector/blob/5803513f0c4cc795c0d1d069f7039c8ca1bd8f7e/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/HttpDataAddress.java#L131.


```[tasklist]
### Checklist
- [x] The PR title is short and expressive.
- [x] I have updated the CHANGELOG.md. See [changelog_update.md](https://github.com/sovity/authority-portal/tree/main/docs/dev/changelog_updates.md) for more information.
- [x] I have performed a **self-review**
```
