### PR TITLE
correctly pass auth header data during asset creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ the detailed section referring to by linking pull requests or issues.
 
 - Both providers and consumers can now terminate contracts.
 - Contracts can be filtered by their termination status.
+- Fixed an issue that caused the auth information to get lost during asset creation.
 
 #### Patch
 

--- a/src/app/core/services/asset-data-source-mapper.ts
+++ b/src/app/core/services/asset-data-source-mapper.ts
@@ -2,6 +2,7 @@ import {Injectable} from '@angular/core';
 import {UiDataSource} from '@sovity.de/edc-client';
 import {AssetDatasourceFormValue} from '../../routes/connector-ui/asset-page/asset-edit-dialog/form/model/asset-datasource-form-model';
 import {HttpDatasourceHeaderFormValue} from '../../routes/connector-ui/asset-page/asset-edit-dialog/form/model/http-datasource-header-form-model';
+import {getAuthFields} from '../utils/form-value-utils';
 import {QueryParamsMapper} from './query-params-mapper';
 
 @Injectable({providedIn: 'root'})
@@ -53,12 +54,19 @@ export class AssetDataSourceMapper {
       formValue.httpQueryParams ?? [],
     );
 
+    const authFields = getAuthFields(formValue);
+
     return {
       type: 'HTTP_DATA',
       httpData: {
         method: formValue.httpMethod,
         baseUrl,
         queryString: queryString ?? undefined,
+        authHeaderName: authFields.authHeaderName ?? undefined,
+        authHeaderValue: {
+          secretName: authFields.authHeaderSecretName ?? undefined,
+          rawValue: authFields.authHeaderValue ?? undefined,
+        },
         headers: this.buildHttpHeaders(formValue.httpHeaders ?? []),
         enableMethodParameterization: formValue.httpProxyMethod,
         enablePathParameterization: formValue.httpProxyPath,

--- a/src/app/core/services/transfer-data-sink-mapper.ts
+++ b/src/app/core/services/transfer-data-sink-mapper.ts
@@ -1,6 +1,7 @@
 import {Injectable} from '@angular/core';
 import {HttpDatasourceHeaderFormValue} from '../../routes/connector-ui/asset-page/asset-edit-dialog/form/model/http-datasource-header-form-model';
 import {ContractAgreementTransferDialogFormValue} from '../../routes/connector-ui/contract-agreement-page/contract-agreement-transfer-dialog/contract-agreement-transfer-dialog-form-model';
+import {getAuthFields} from '../utils/form-value-utils';
 import {mapKeys, removeNullValues} from '../utils/record-utils';
 import {DataAddressProperty} from './models/data-address-properties';
 import {HttpDataAddressParams} from './models/http-data-address-params';
@@ -82,7 +83,7 @@ export class TransferDataSinkMapper {
     formValue: ContractAgreementTransferDialogFormValue,
   ): HttpDataAddressParams {
     const {authHeaderName, authHeaderValue, authHeaderSecretName} =
-      this.getAuthFields(formValue);
+      getAuthFields(formValue);
 
     let method = formValue?.httpMethod?.trim().toUpperCase() || null;
 
@@ -103,31 +104,6 @@ export class TransferDataSinkMapper {
       queryParams,
       headers: this.buildHttpHeaders(formValue?.httpHeaders ?? []),
     };
-  }
-
-  private getAuthFields(
-    formValue: ContractAgreementTransferDialogFormValue | undefined,
-  ): {
-    authHeaderName: string | null;
-    authHeaderValue: string | null;
-    authHeaderSecretName: string | null;
-  } {
-    let authHeaderName: string | null = null;
-    if (formValue?.httpAuthHeaderType !== 'None') {
-      authHeaderName = formValue?.httpAuthHeaderName?.trim() || null;
-    }
-
-    let authHeaderValue: string | null = null;
-    if (authHeaderName && formValue?.httpAuthHeaderType === 'Value') {
-      authHeaderValue = formValue?.httpAuthHeaderValue?.trim() || null;
-    }
-
-    let authHeaderSecretName: string | null = null;
-    if (authHeaderName && formValue?.httpAuthHeaderType === 'Vault-Secret') {
-      authHeaderSecretName =
-        formValue?.httpAuthHeaderSecretName?.trim() || null;
-    }
-    return {authHeaderName, authHeaderValue, authHeaderSecretName};
   }
 
   private buildHttpHeaders(

--- a/src/app/core/utils/form-value-utils.ts
+++ b/src/app/core/utils/form-value-utils.ts
@@ -1,0 +1,29 @@
+import {AssetDatasourceFormValue} from '../../routes/connector-ui/asset-page/asset-edit-dialog/form/model/asset-datasource-form-model';
+import {ContractAgreementTransferDialogFormValue} from '../../routes/connector-ui/contract-agreement-page/contract-agreement-transfer-dialog/contract-agreement-transfer-dialog-form-model';
+
+export function getAuthFields(
+  formValue:
+    | AssetDatasourceFormValue
+    | ContractAgreementTransferDialogFormValue
+    | undefined,
+): {
+  authHeaderName: string | null;
+  authHeaderValue: string | null;
+  authHeaderSecretName: string | null;
+} {
+  let authHeaderName: string | null = null;
+  if (formValue?.httpAuthHeaderType !== 'None') {
+    authHeaderName = formValue?.httpAuthHeaderName?.trim() || null;
+  }
+
+  let authHeaderValue: string | null = null;
+  if (authHeaderName && formValue?.httpAuthHeaderType === 'Value') {
+    authHeaderValue = formValue?.httpAuthHeaderValue?.trim() || null;
+  }
+
+  let authHeaderSecretName: string | null = null;
+  if (authHeaderName && formValue?.httpAuthHeaderType === 'Vault-Secret') {
+    authHeaderSecretName = formValue?.httpAuthHeaderSecretName?.trim() || null;
+  }
+  return {authHeaderName, authHeaderValue, authHeaderSecretName};
+}


### PR DESCRIPTION
This PR fixes #768.

To avoid duplicated code, I extracted `getAuthFields` to a dedicated `form-value-utils.ts` file.


```[tasklist]
### Checklist
- [x] The PR title is short and expressive.
- [x] I have updated the CHANGELOG.md. See [changelog_update.md](https://github.com/sovity/authority-portal/tree/main/docs/dev/changelog_updates.md) for more information.
- [x] I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.
- [x] I have performed a **self-review**
```
