### PR TITLE
Fix date format in Policy Expression mat-hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ the detailed section referring to by linking pull requests or issues.
 - Assets Page search input field is now case insensitive
 - Performance improvement when fetching a single contract agreement
 - Temporary reimplement the Edit Asset as a Dialog
+- Fixed wrong date format displayed when creating a new data offer
 
 ## [v4.1.0] - 2024-07-24
 

--- a/src/app/component-library/policy-editor/model/policy-verbs.ts
+++ b/src/app/component-library/policy-editor/model/policy-verbs.ts
@@ -27,8 +27,8 @@ export const SUPPORTED_POLICY_VERBS: PolicyVerbConfig[] = [
       'Time at which the policy is evaluated. This can be used to restrict the data offer to certain time periods',
     supportedOperators: ['GEQ', 'LEQ', 'GT', 'LT'],
     operandRightType: 'DATE',
-    operandRightPlaceholder: 'MM/DD/YYYY',
-    operandRightHint: 'MM/DD/YYYY',
+    operandRightPlaceholder: 'DD/MM/YYYY',
+    operandRightHint: 'DD/MM/YYYY',
     adapter: localDateAdapter,
   },
   {


### PR DESCRIPTION
_What issues does this PR close?_
closes #1410 Policy Creation section shows wrong date format

### Before
![image](https://github.com/user-attachments/assets/5da4b9c9-203d-46d5-a6f1-64b638b60fa7)

### After
Single Date
![image](https://github.com/user-attachments/assets/f1761daa-9bce-4589-857b-5e05a7e0e97e)
Date Timespan
![image](https://github.com/user-attachments/assets/93d42287-4ff6-45de-980e-8a10b425e8c1)

### Also correct in Timespan restriction dialog
![image](https://github.com/user-attachments/assets/81cef27c-c5e8-4dbe-af6a-4c2e584ae767)


```[tasklist]
### Checklist
- [x] The PR title is short and expressive.
- [ ] I have updated the CHANGELOG.md. See [changelog_update.md](https://github.com/sovity/authority-portal/tree/main/docs/dev/changelog_updates.md) for more information.
- [ ] I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.
- [x] I have performed a **self-review**
```
