### PR TITLE
feat: Add Contract Offer Id Element back to the Catalog Browser Detail Dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ the detailed section referring to by linking pull requests or issues.
 
 #### Patch
 
-- Added Contract Offer Id Element back to the Catalog Browser Detail Dialog
+- Data Offer details now display the contract ID for each contract offer
 
 ## [v4.1.3] - 2024-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ the detailed section referring to by linking pull requests or issues.
 
 #### Patch
 
+- Added Contract Offer Id Element back to the Catalog Browser Detail Dialog
+
 ## [v4.1.3] - 2024-09-03
 
 ### Overview

--- a/src/app/component-library/catalog/contract-offer-mini-list/contract-offer-mini-list.component.html
+++ b/src/app/component-library/catalog/contract-offer-mini-list/contract-offer-mini-list.component.html
@@ -22,6 +22,14 @@
   </div>
 
   <property-grid
+    [columns]="1"
+    [props]="
+      contractOfferIdGroup(contractOffer.contractOfferId)
+    "></property-grid>
+
+  <br />
+
+  <property-grid
     [columns]="3"
     [props]="contractOffer.properties"></property-grid>
 

--- a/src/app/component-library/catalog/contract-offer-mini-list/contract-offer-mini-list.component.html
+++ b/src/app/component-library/catalog/contract-offer-mini-list/contract-offer-mini-list.component.html
@@ -22,12 +22,11 @@
   </div>
 
   <property-grid
+    class="mb-3"
     [columns]="1"
     [props]="
       contractOfferIdGroup(contractOffer.contractOfferId)
     "></property-grid>
-
-  <br />
 
   <property-grid
     [columns]="3"

--- a/src/app/component-library/catalog/contract-offer-mini-list/contract-offer-mini-list.component.ts
+++ b/src/app/component-library/catalog/contract-offer-mini-list/contract-offer-mini-list.component.ts
@@ -8,6 +8,7 @@ import {
 import {DataOffer} from 'src/app/core/services/models/data-offer';
 import {ContractNegotiationService} from '../../../core/services/contract-negotiation.service';
 import {ContractOffer} from '../../../core/services/models/contract-offer';
+import {PropertyGridField} from '../../property-grid/property-grid/property-grid-field';
 
 @Component({
   selector: 'contract-offer-mini-list',
@@ -25,4 +26,15 @@ export class ContractOfferMiniListComponent {
   negotiateClick = new EventEmitter<ContractOffer>();
 
   constructor(public contractNegotiationService: ContractNegotiationService) {}
+
+  contractOfferIdGroup(id: string): PropertyGridField[] {
+    return [
+      {
+        icon: 'category',
+        label: 'Contract Offer Id',
+        text: this.data.contractOffers.find((it) => it.contractOfferId == id)
+          ?.contractOfferId,
+      },
+    ];
+  }
 }


### PR DESCRIPTION
_What issues does this PR close?_
#795 Contract offer ID is missing on catalog browser view page

Before
![image](https://github.com/user-attachments/assets/d016711b-c343-49b1-ad69-ab20b36ce12f)

After
![image](https://github.com/user-attachments/assets/60a258b8-4021-423f-9518-ecc84d23d48d)



```[tasklist]
### Checklist
- [x] The PR title is short and expressive.
- [x] I have updated the CHANGELOG.md. See [changelog_update.md](https://github.com/sovity/authority-portal/tree/main/docs/dev/changelog_updates.md) for more information.
- [ ] I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.
- [x] I have performed a **self-review**
```
