### PR TITLE
chore: rename Name to Title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ the detailed section referring to by linking pull requests or issues.
 
 #### Patch
 
+- Renamed 'Name' to 'Title' in the Create Data Offer and Create Asset.
+
 ## [v4.1.3] - 2024-09-03
 
 ### Overview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ the detailed section referring to by linking pull requests or issues.
 
 #### Patch
 
-- Renamed 'Name' to 'Title' in the Create Data Offer and Create Asset.
+- Changed wording on the data offer creation page
 - Data Offer details now display the contract ID for each contract offer
 
 ## [v4.1.3] - 2024-09-03

--- a/src/app/component-library/edit-asset-form/edit-asset-form/edit-asset-form.component.html
+++ b/src/app/component-library/edit-asset-form/edit-asset-form/edit-asset-form.component.html
@@ -398,12 +398,12 @@
     <edit-asset-form-group
       myTitle="General Information"
       description="Fill out general information about the asset">
-      <!-- Name -->
+      <!-- Title -->
       <edit-asset-form-input
         fieldId="create-asset-form-name"
-        label="Name"
+        label="Title"
         placeholder="My Asset"
-        tooltip="The main name of your asset. It will also be the name of the data offering displayed in the catalog."
+        tooltip="The main title of your asset. It will also be the title of the data offering displayed in the catalog."
         [ctrl]="form.general.controls.name"></edit-asset-form-input>
 
       <!-- Asset ID -->

--- a/src/app/routes/connector-ui/asset-page/asset-edit-dialog/asset-edit-dialog.component.html
+++ b/src/app/routes/connector-ui/asset-page/asset-edit-dialog/asset-edit-dialog.component.html
@@ -9,9 +9,9 @@
         <ng-template matStepLabel>General Information</ng-template>
         <div class="flex flex-col mt-[10px]">
           <div class="flex flex-row space-x-[10px]">
-            <!-- Name -->
+            <!-- Title -->
             <mat-form-field class="grow">
-              <mat-label>Name</mat-label>
+              <mat-label>Title</mat-label>
               <input
                 matInput
                 autocomplete="new-name"
@@ -20,7 +20,7 @@
                 class="!scale-[0.9]"
                 mat-icon-button
                 matSuffix
-                matTooltip="The main name of your asset. It will also be the name of the data offering displayed in the catalog.">
+                matTooltip="The main title of your asset. It will also be the title of the data offering displayed in the catalog.">
                 <mat-icon>info_outline</mat-icon>
               </button>
             </mat-form-field>


### PR DESCRIPTION
_What issues does this PR close?_
closes #800 Attribute names are inconsistent on asset creation (EDC UI) vs the data catalog page (AP)

Only cosmetic (no form control name) changes in this PR to avoid compat issues and BE refactoring

### Create Data Offer Page
![image](https://github.com/user-attachments/assets/b0cfcf21-2e58-418d-a310-b6926da8f716)

### Create New Asset Dialog
![image](https://github.com/user-attachments/assets/1339afd0-4832-442d-8755-dd7db0c0be5c)


```[tasklist]
### Checklist
- [x] The PR title is short and expressive.
- [x] I have updated the CHANGELOG.md. See [changelog_update.md](https://github.com/sovity/authority-portal/tree/main/docs/dev/changelog_updates.md) for more information.
- [ ] I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.
- [x] I have performed a **self-review**
```
