### PR TITLE
fix: invalid configuration after version upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ the detailed section referring to by linking pull requests or issues.
 - Used createDataOffer endpoint to create an asset, policies and a contract
   definition in a single call
   ([#841](https://github.com/sovity/edc-ui/issues/841))
+- Fixed config not being applied properly after a version upgrade
 
 ### Deployment Migration Notes
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,9 +28,9 @@ COPY docker/default.conf.template etc/nginx/templates/default.conf.template
 # so that the automatic envsubst templating is not disabled.
 COPY docker/99-generate-app-config.sh /docker-entrypoint.d/99-generate-app-config.sh
 
-RUN ln -sf /tmp/app-config.json /usr/share/nginx/html/assets/config/app-config.json \
+RUN ln -sf /tmp/app-config.json /usr/share/nginx/html/assets/config/app-configuration.json \
   # Nginx is configured to reject symlinks that point to a file owned by a different user, for security reasons
-  && chown --no-dereference nginx:root /usr/share/nginx/html/assets/config/app-config.json
+  && chown --no-dereference nginx:root /usr/share/nginx/html/assets/config/app-configuration.json
 
 # Switch back to unprivileged user for runtime
 USER nginx:nginx

--- a/docker/default.conf.template
+++ b/docker/default.conf.template
@@ -20,4 +20,9 @@ server {
         index index.html;
         try_files /index.html =404;
     }
+
+    location ~* ^/assets/config/app-configuration\.json$ {
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
+        expires -1;
+    }
 }

--- a/src/app/core/config/app-config-initializer.ts
+++ b/src/app/core/config/app-config-initializer.ts
@@ -11,7 +11,7 @@ export async function loadAppConfig(): Promise<AppConfig> {
   const builder = new AppConfigBuilder();
   const fetcher = new AppConfigFetcher(merger);
   return fetcher
-    .fetchEffectiveConfig('/assets/config/app-config.json', null)
+    .fetchEffectiveConfig('/assets/config/app-configuration.json', null)
     .then((json) => builder.buildAppConfig(json))
     .then((config) => (appConfig = config));
 }


### PR DESCRIPTION
This PR fixes a caching issue wherein the app-config.json was aggressively cached and always loaded from disk cache without validation which caused new deployments on the same URL to use an outdated configuration.

See https://github.com/sovity/authority-portal/pull/325 for more information

```[tasklist]
### Checklist
- [x] The PR title is short and expressive.
- [x] I have updated the CHANGELOG.md. See [changelog_update.md](https://github.com/sovity/authority-portal/tree/main/docs/dev/changelog_updates.md) for more information.
- [ ] I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.
- [x] I have performed a **self-review**
```
