### PR TITLE
fix: date to datetime conversion with operators LT and GT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ the detailed section referring to by linking pull requests or issues.
   definition in a single call
   ([#841](https://github.com/sovity/edc-ui/issues/841))
 - Fixed config not being applied properly after a version upgrade
+- Fixed Date to DateTime conversion issues when using operators `LT` and `GT`
+  ([#846](https://github.com/sovity/edc-ui/issues/846))
 
 ### Deployment Migration Notes
 

--- a/src/app/shared/business/policy-editor/model/policy-form-adapter.ts
+++ b/src/app/shared/business/policy-editor/model/policy-form-adapter.ts
@@ -121,7 +121,7 @@ export const jsonAdapter: PolicyFormAdapter<string> = {
 };
 
 const isUpperBound = (operator: PolicyOperatorConfig) =>
-  operator.id === 'LT' || operator.id === 'LEQ';
+  operator.id === 'GT' || operator.id === 'LEQ';
 
 /**
  * Helper function for reducing mental complexity of mapping code:


### PR DESCRIPTION
closes #846

Explanation:

```
day start |        | day end
GEQ       |        |
LT        |        |
          |        | GT (+1 day)
          |        | LEQ (+1 day)
```