### PR TITLE
fix: data offer renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,16 @@ the detailed section referring to by linking pull requests or issues.
 
 #### Patch
 
-- Fixed wrong button label stating "Method Parameterization" instead of "Path Parameterization" ([#857](https://github.com/sovity/edc-ui/issues/857))
-- Made Custom Http Method mandatory if the corresponding option is chosen ([#739](https://github.com/sovity/edc-ui/issues/739))
-
+- Fixed wrong button label stating "Method Parameterization" instead of "Path
+  Parameterization" ([#857](https://github.com/sovity/edc-ui/issues/857))
+- Made Custom Http Method mandatory if the corresponding option is chosen
+  ([#739](https://github.com/sovity/edc-ui/issues/739))
+- Fixed inconsistent renaming of "Contract Definition" to "Data Offer" after
+  i18n ([#831](https://github.com/sovity/edc-ui/issues/831))
 
 ### Deployment Migration Notes
 
 _No special deployment migration steps required_
-
 
 ## [v4.1.5] - 2024-09-26
 
@@ -45,11 +47,12 @@ MDS Patch release
   ([#820](https://github.com/sovity/edc-ui/issues/820))
 - Fixed cropping of Contract Offer Ids on catalog browser page
   ([#795](https://github.com/sovity/edc-ui/issues/795))
-- Used the `createDataOffer` endpoint to create an asset, policies and a contract definition in a single call
+- Used the `createDataOffer` endpoint to create an asset, policies and a
+  contract definition in a single call
   ([#841](https://github.com/sovity/edc-ui/issues/841))
 - Fixed config not being applied properly after a version upgrade
-- Fixed Date to DateTime conversion issues when using operators less than `LT` and greater than `GT`
-  ([#846](https://github.com/sovity/edc-ui/issues/846))
+- Fixed Date to DateTime conversion issues when using operators less than `LT`
+  and greater than `GT` ([#846](https://github.com/sovity/edc-ui/issues/846))
 - Added initial support for UI internationalization
   ([#680](https://github.com/sovity/edc-ui/issues/680))
 - Implemented Data Offer wizard wording change request by MDS

--- a/src/app/routes/connector-ui/dashboard-page/dashboard-page/dashboard-page.component.html
+++ b/src/app/routes/connector-ui/dashboard-page/dashboard-page/dashboard-page.component.html
@@ -31,7 +31,7 @@
     <div class="flex flex-row flex-wrap gap-[16px]">
       <dashboard-kpi-card
         class="flex-even-sized"
-        [label]="'dashboard_page.your_def' | translate"
+        [label]="'dashboard_page.your_data_offers' | translate"
         [kpi]="data.numContractDefinitions"></dashboard-kpi-card>
 
       <dashboard-kpi-card

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -312,6 +312,7 @@
   "dashboard_page.trans_pro": "Transfer Processes",
   "dashboard_page.transfer": "Transfer History",
   "dashboard_page.your_assets": "Your Assets",
+  "dashboard_page.your_data_offers": "Your Data Offers",
   "dashboard_page.your_def": "Your Contract Definitions",
   "dashboard_page.your_pol": "Your Policies",
   "edit_asset_page.title": "Edit Asset",


### PR DESCRIPTION
_What issues does this PR close?_
#831 Inconsistent renaming "Contract Definition" to "Data Offer"

![image](https://github.com/user-attachments/assets/f144cc8d-b6ce-4838-b3e9-b495bf2d548e)


```[tasklist]
### Checklist
- [x] The PR title is short and expressive.
- [x] I have updated the CHANGELOG.md. See [changelog_update.md](https://github.com/sovity/authority-portal/tree/main/docs/dev/changelog_updates.md) for more information.
- [ ] I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.
- [x] I have performed a **self-review**
```
