### PR TITLE
Fix edit asset form validator

### DIFF
--- a/src/app/core/services/api/fake-backend/connector-fake-impl/data-offer-fake-service.ts
+++ b/src/app/core/services/api/fake-backend/connector-fake-impl/data-offer-fake-service.ts
@@ -25,6 +25,17 @@ const checkIdAvailability = (id: string): void => {
   }
 };
 
+const checkIfNoAlwaysTruePolicyExists = (): void => {
+  if (policyDefinitionIdAvailable(ALWAYS_TRUE_POLICY_ID).available) {
+    createPolicyDefinitionV2({
+      policyDefinitionId: ALWAYS_TRUE_POLICY_ID,
+      expression: {
+        type: 'EMPTY',
+      },
+    });
+  }
+};
+
 export const createDataOffer = (
   request: DataOfferCreationRequest,
 ): IdResponseDto => {
@@ -32,6 +43,7 @@ export const createDataOffer = (
   let accessPolicyId = null;
   let contractPolicyId = null;
 
+  checkIfNoAlwaysTruePolicyExists();
   checkIdAvailability(commonId);
   createAsset(request.uiAssetCreateRequest);
 

--- a/src/app/shared/business/edit-asset-form/form/edit-asset-form-validators.ts
+++ b/src/app/shared/business/edit-asset-form/form/edit-asset-form-validators.ts
@@ -21,7 +21,7 @@ export class EditAssetFormValidators {
   /**
    * Use on asset control, reset asset control on publish mode changes, accesses parent form
    */
-isValidId(): AsyncValidatorFn {
+  isValidId(): AsyncValidatorFn {
     return (control: AbstractControl): Observable<ValidationErrors | null> => {
       const value = control?.parent?.parent?.value as EditAssetFormValue | null;
       if (value?.mode !== 'CREATE') {

--- a/src/app/shared/business/edit-asset-form/form/edit-asset-form-validators.ts
+++ b/src/app/shared/business/edit-asset-form/form/edit-asset-form-validators.ts
@@ -21,7 +21,7 @@ export class EditAssetFormValidators {
   /**
    * Use on asset control, reset asset control on publish mode changes, accesses parent form
    */
-  isValidId(): AsyncValidatorFn {
+isValidId(): AsyncValidatorFn {
     return (control: AbstractControl): Observable<ValidationErrors | null> => {
       const value = control?.parent?.parent?.value as EditAssetFormValue | null;
       if (value?.mode !== 'CREATE') {
@@ -29,20 +29,7 @@ export class EditAssetFormValidators {
       }
 
       const assetId = control.value! as string;
-      if (value.publishMode === 'PUBLISH_UNRESTRICTED') {
-        return combineLatest([
-          this.assetIdExistsErrorMessage(assetId),
-          this.contractDefinitionIdErrorMessage(assetId),
-          this.policyIdExistsErrorMessage(ALWAYS_TRUE_POLICY_ID).pipe(
-            map((errorMessage) =>
-              // We want to throw an error if always-true was not found
-              errorMessage ? null : 'Always True Policy does not exist.',
-            ),
-          ),
-        ]).pipe(
-          map((errorMessages) => this.buildValidationErrors(errorMessages)),
-        );
-      } else if (value.publishMode === 'PUBLISH_RESTRICTED') {
+      if (value.publishMode !== 'DO_NOT_PUBLISH') {
         return combineLatest([
           this.assetIdExistsErrorMessage(assetId),
           this.contractDefinitionIdErrorMessage(assetId),
@@ -55,7 +42,6 @@ export class EditAssetFormValidators {
           map((result) => this.buildValidationErrors([result])),
         );
       }
-
       return of(null);
     };
   }

--- a/src/app/shared/business/edit-asset-form/form/edit-asset-form-validators.ts
+++ b/src/app/shared/business/edit-asset-form/form/edit-asset-form-validators.ts
@@ -8,7 +8,6 @@ import {Observable, combineLatest, of} from 'rxjs';
 import {catchError, map} from 'rxjs/operators';
 import {IdAvailabilityResponse} from '@sovity.de/edc-client';
 import {EdcApiService} from 'src/app/core/services/api/edc-api.service';
-import {ALWAYS_TRUE_POLICY_ID} from './model/always-true-policy-id';
 import {EditAssetFormValue} from './model/edit-asset-form-model';
 
 /**


### PR DESCRIPTION
_What issues does this PR close?_

if the always-true policy was removed, BE creates a new always-true policy
![image](https://github.com/user-attachments/assets/753232c4-a3f2-4c1a-a9b9-3e6fe3320b69)

So the old check if always-true policy doesn't exist isn't necessary anymore
![image](https://github.com/user-attachments/assets/75ff14e7-1560-4543-bb3a-af1a47385af6)

But the old checks work as intended
![image](https://github.com/user-attachments/assets/4392c31a-320b-4c42-a4b5-065938ebee0e)
![image](https://github.com/user-attachments/assets/77936fd4-d277-4a10-aa49-3c315faeea88)


```[tasklist]
### Checklist
- [x] The PR title is short and expressive.
- [ ] I have updated the CHANGELOG.md. See [changelog_update.md](https://github.com/sovity/authority-portal/tree/main/docs/dev/changelog_updates.md) for more information.
- [ ] I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.
- [x] I have performed a **self-review**
```
