### PR TITLE
fix description label

### DIFF
--- a/src/app/shared/business/edit-asset-form/edit-asset-form.component.html
+++ b/src/app/shared/business/edit-asset-form/edit-asset-form.component.html
@@ -159,9 +159,7 @@
                     ? ('general.disable' | translate)
                     : ('general.enable' | translate)
                 }}
-                {{
-                  'create_data_offer_page.path_parameterization' | translate
-                }}
+                {{ 'create_data_offer_page.path_parameterization' | translate }}
               </button>
             </div>
           </div>
@@ -482,9 +480,7 @@
       <!-- Description -->
       <edit-asset-form-textarea
         fieldId="create-asset-form-description"
-        [label]="
-          'create_data_offer_page.reference_files_description_label' | translate
-        "
+        [label]="'create_data_offer_page.description' | translate"
         [placeholder]="
           '# My Asset\n\nAt vero eos et accusam et justo duo dolores et ea rebum.\n\n## Details\n\nAt vero eos et accusam et justo duo dolores et ea **rebum**.'
         "


### PR DESCRIPTION
_What issues does this PR close?_
#870 Wrong label for Description field on asset creation dialog

![image](https://github.com/user-attachments/assets/f16c2529-b48b-40fe-ac6e-7446874f652a)
![image](https://github.com/user-attachments/assets/54559ebf-1e2a-433b-8620-79d16886931f)

```[tasklist]
### Checklist
- [x] The PR title is short and expressive.
- [ ] I have updated the CHANGELOG.md and linked the changes to their issues. See [changelog_update.md](https://github.com/sovity/edc-ui/tree/main/docs/dev/changelog_updates.md) for more information.
- [ ] I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.
- [x] I have performed a **self-review**
```
