### PR TITLE
Fix page title after i18n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ the detailed section referring to by linking pull requests or issues.
 
 #### Patch
 
+- Fix broken title after i18n
+  ([#844](https://github.com/sovity/edc-ui/issues/844))
+
 ### Deployment Migration Notes
 
 _No special deployment migration steps required_

--- a/src/app/core/services/page-title-strategy.ts
+++ b/src/app/core/services/page-title-strategy.ts
@@ -5,7 +5,7 @@ import {
   RouterStateSnapshot,
   TitleStrategy,
 } from '@angular/router';
-import {Subject, switchMap} from 'rxjs';
+import {Subject} from 'rxjs';
 import {TranslateService} from '@ngx-translate/core';
 
 @Injectable()
@@ -17,9 +17,9 @@ export class CustomPageTitleStrategy extends TitleStrategy {
     private title: Title,
   ) {
     super();
-    this.rawTitle$
-      .pipe(switchMap((title) => this.translateService.get(title)))
-      .subscribe((title) => this.title.setTitle(title));
+    this.rawTitle$.subscribe((title) =>
+      this.title.setTitle(this.translateService.instant(title)),
+    );
   }
 
   override updateTitle(snapshot: RouterStateSnapshot): void {


### PR DESCRIPTION
This fixes #844 using `translateService.instant('...')`, considering the comment from #845.


```[tasklist]
### Checklist
- [x] The PR title is short and expressive.
- [x] I have updated the CHANGELOG.md and linked the changes to their issues. See [changelog_update.md](https://github.com/sovity/edc-ui/tree/main/docs/dev/changelog_updates.md) for more information.
- [ ] I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.
- [x] I have performed a **self-review**
```
