### PR TITLE
feat: rearrange sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ the detailed section referring to by linking pull requests or issues.
 
 - Fix wrong placeholders for On Request data offer type
   ([#878](https://github.com/sovity/edc-ui/issues/878))
+- Rearrange Sidebar Navigation Groups
+  ([#836](https://github.com/sovity/edc-ui/issues/836))
 
 ### Deployment Migration Notes
 

--- a/src/app/core/services/nav-items-builder.ts
+++ b/src/app/core/services/nav-items-builder.ts
@@ -12,10 +12,27 @@ import {NavItemGroup} from './models/nav-item-group';
 export class NavItemsBuilder {
   private navItemGroups: NavItemGroup[] = [
     {
-      items: [{path: 'dashboard', icon: 'data_usage', title: 'Dashboard'}],
+      items: [
+        {path: 'dashboard', icon: 'data_usage', title: 'Dashboard'},
+        {
+          path: 'catalog-browser',
+          icon: 'sim_card',
+          title: 'catalog_browser_page.title',
+        },
+        {
+          path: 'contracts',
+          icon: 'assignment_turned_in',
+          title: 'contract_agreement_page.title',
+        },
+        {
+          path: 'transfer-history',
+          icon: 'assignment',
+          title: 'transfer_history_page.title',
+        },
+      ],
     },
     {
-      title: 'Providing',
+      title: 'Provide',
       items: [
         {
           path: 'create-asset',
@@ -35,26 +52,7 @@ export class NavItemsBuilder {
         },
       ],
     },
-    {
-      title: 'Consuming',
-      items: [
-        {
-          path: 'catalog-browser',
-          icon: 'sim_card',
-          title: 'catalog_browser_page.title',
-        },
-        {
-          path: 'contracts',
-          icon: 'assignment_turned_in',
-          title: 'contract_agreement_page.title',
-        },
-        {
-          path: 'transfer-history',
-          icon: 'assignment',
-          title: 'transfer_history_page.title',
-        },
-      ],
-    },
+
     {
       items: [
         {


### PR DESCRIPTION
_What issues does this PR close?_
closes #836 Sidebar with inconsistent separation in Providing and Consuming sections

**before:**

![image](https://github.com/user-attachments/assets/601d69d1-a98f-460c-bda0-0fd12b03823b)

**after:**

![image](https://github.com/user-attachments/assets/c0b5a9cf-8959-42c8-8865-6def794841d9)


```[tasklist]
### Checklist
- [x] The PR title is short and expressive.
- [x] I have updated the CHANGELOG.md and linked the changes to their issues. See [changelog_update.md](https://github.com/sovity/authority-portal/blob/main/docs/dev/changelog_updates.md) for more information.
- [ ] I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.
- [x] I have performed a **self-review**
```
